### PR TITLE
Fix crash on import by updating Flask requirement

### DIFF
--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.1
+Flask==2.0.2
 requests===2.23.0
 xlrd==1.2.0
 sesamutils==0.1.10


### PR DESCRIPTION
The newest release crashes due to an import error, using a newer version of Flask fixes this